### PR TITLE
Update openai-asr.ts - make speech recognition model configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -141,6 +141,8 @@ OPENAI_API_KEY=openai_api_key
 OPENAI_IMAGE_MODEL=dall-e-3
 # if you are using openai as VISION_SERVER, specify the vision model for openai image understanding tasks, if not set, the default model will be the same as OPENAI_LLM_MODEL model
 # OPENAI_VISION_MODEL=gpt-4o
+# if you are using an OpenAI-compatible endpoint that supports different speech recognition models, you can specify it here. Defaults to whisper-1.
+# OPENAI_ASR_MODEL="whisper-1"
 
 ## Grok
 # if you are using grok as LLM server, please set the following environment variables

--- a/src/cloud-api/openai/openai-asr.ts
+++ b/src/cloud-api/openai/openai-asr.ts
@@ -1,5 +1,10 @@
 import fs from "fs";
+import dotenv from "dotenv";
 import { openai } from "./openai"; // Assuming openai is exported from openai.ts
+
+dotenv.config();
+
+const OpenAiAsrModel = process.env.OPENAI_ASR_MODEL || "whisper-1"; //default to whisper-1 - changeable if openai compatible provider like NanoGPT is used
 
 export const recognizeAudio = async (
   audioFilePath: string
@@ -16,7 +21,7 @@ export const recognizeAudio = async (
   try {
     const transcription = await openai.audio.transcriptions.create({
       file: fs.createReadStream(audioFilePath),
-      model: "whisper-1",
+      model: OpenAiAsrModel,
     });
     console.log("Transcription result:", transcription.text);
     return transcription.text;


### PR DESCRIPTION
TTS model is changeable via .env, but not the speech recognition model. If an openAI-compatible provider (other than OpenRouter) is used that has different speech recognition models, it's just logical to have it be configurable.

Qapla'