### PR TITLE
fix: improve Pi compatibility in install script

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -16,9 +16,17 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
-# apt install sox libsox-fmt-mp3 mpg123
+# apt install sox libsox-fmt-mp3 mpg123 and other dependencies
 sudo apt-get update
-sudo apt-get install -y sox mpg123 libsox-fmt-mp3 python3-dev libcairo2 libcairo2-dev unzip python3-lgpio ffmpeg
+sudo apt-get install -y sox mpg123 libsox-fmt-mp3 python3-dev libcairo2 libcairo2-dev unzip python3-lgpio ffmpeg \
+    python3-numpy python3-pillow python3-flask python3-opencv python3-spidev python3-rpi.gpio patchelf
+
+# Fix libmad executable stack issue on modern kernels (required for MP3 support)
+# Without this fix, sox cannot encode/decode MP3 files on Raspberry Pi OS Bookworm+
+if [ -f "/lib/arm-linux-gnueabihf/libmad.so.0" ]; then
+    echo "Fixing libmad executable stack flag for MP3 support..."
+    sudo patchelf --clear-execstack /lib/arm-linux-gnueabihf/libmad.so.0 2>/dev/null || true
+fi
 
 # enable spi
 sudo raspi-config nonint do_spi 0
@@ -127,6 +135,18 @@ install_node_binary() {
     chmod +x $TEMP_DIR/install-node-v20.19.5.sh
     sudo bash $TEMP_DIR/install-node-v20.19.5.sh
     rm -rf $TEMP_DIR
+
+    # Add /opt/nodejs/bin to PATH if not already present
+    if [ -d "/opt/nodejs/bin" ]; then
+        export PATH="/opt/nodejs/bin:$PATH"
+        if ! grep -q "/opt/nodejs/bin" "$HOME/.bashrc" 2>/dev/null; then
+            echo 'export PATH="/opt/nodejs/bin:$PATH"' >> "$HOME/.bashrc"
+            echo "Added /opt/nodejs/bin to PATH in ~/.bashrc"
+        fi
+        if ! grep -q "/opt/nodejs/bin" "$HOME/.profile" 2>/dev/null; then
+            echo 'export PATH="/opt/nodejs/bin:$PATH"' >> "$HOME/.profile"
+        fi
+    fi
 
     # Verify installation
     if command_exists node && [[ "$(node -v)" =~ ^v20 ]]; then


### PR DESCRIPTION
## Summary
- Fix libmad executable stack issue that breaks MP3 recording on Raspberry Pi OS Bookworm+
- Add missing Python dependencies (numpy, pillow, flask, opencv, spidev, rpi.gpio) via apt
- Add /opt/nodejs/bin to PATH for Pi Zero binary Node.js install

## Problem
On modern Raspberry Pi OS (Bookworm and later), the `libmad` library has an executable stack flag that newer kernels block for security reasons. This causes `sox` to fail with "no handler for file type mp3" even though `libsox-fmt-mp3` is installed.

The error manifests as:
```
sox FAIL formats: no handler for given file type `mp3'
```

Root cause (visible via Python ctypes):
```
OSError: libmad.so.0: cannot enable executable stack as shared object requires: Invalid argument
```

## Solution
Use `patchelf --clear-execstack` on libmad.so.0 during installation to clear the legacy executable stack flag.

Also includes:
- Python packages that were missing from apt install (required for display driver)
- PATH fix for Pi Zero users where Node.js is installed to /opt/nodejs/bin

## Test plan
- [x] Tested on Raspberry Pi Zero 2W with Raspberry Pi OS Bookworm
- [x] Verified MP3 recording works after the fix
- [x] Verified Python display driver starts without import errors

🤖 Generated with [Claude Code](https://claude.ai/code)